### PR TITLE
updating guzzlehttp/guzzle to 5.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "5.3.0"
+    "guzzlehttp/guzzle": "^5.3.1"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Hi,

Guzzle 5.3.0 break on php 7.1 version. Made an update to guzzle 5.3.1 version and above. 
Guzzle solved that issue https://github.com/guzzle/guzzle/pull/1393

Thanks.
